### PR TITLE
[CU-86etjp92f] Fix the logic bug about it should get the task ticket from the git branch name, doesn't from the git commits.

### DIFF
--- a/create_pr_bot/bot.py
+++ b/create_pr_bot/bot.py
@@ -298,17 +298,17 @@ class CreatePrAIBot:
             traceback.print_exc()
             return []
 
-    def extract_ticket_ids(self, commits: List[Dict[str, Any]]) -> List[str]:
+    def extract_ticket_id(self, branch_name: str) -> str:
         """
-        Extract ticket IDs from commit messages.
+        Extract ticket ID from the git branch name.
 
         Args:
-            commits: List of commit details
+            branch_name: the git branch name
 
         Returns:
-            List of unique ticket IDs
+            The unique ticket ID
         """
-        ticket_ids = set()
+        # ticket_ids = set()
 
         # Common patterns for ticket IDs in commit messages
         # Adjust patterns based on your project's conventions
@@ -319,14 +319,11 @@ class CreatePrAIBot:
             r"Task-(\d+)",  # Generic task format: Task-123
         ]
 
-        for commit in commits:
-            message = commit["message"]
-
-            for pattern in patterns:
-                matches = re.findall(pattern, message)
-                ticket_ids.update(matches)
-
-        return list(ticket_ids)
+        for pattern in patterns:
+            matches = re.search(pattern, branch_name)
+            if matches:
+                return matches.group(0)
+        return ""
 
     def get_ticket_details(self, ticket_ids: List[str]) -> List[BaseImmutableModel]:
         """
@@ -629,11 +626,11 @@ class CreatePrAIBot:
                     return None
 
                 # Step 4-3: Get ticket details
-                logger.info("Extracting ticket IDs from commits...")
-                ticket_ids = self.extract_ticket_ids(commits)
+                logger.info("Extracting ticket IDs from git branch...")
+                ticket_id = self.extract_ticket_id(branch_name)
 
-                logger.info(f"Found ticket IDs: {ticket_ids}")
-                ticket_details = self.get_ticket_details(ticket_ids)
+                logger.info(f"Found ticket ID: {ticket_id}")
+                ticket_details = self.get_ticket_details([ticket_id])
 
                 # Step 4-4: Prepare AI prompt
                 logger.info("Preparing AI prompt...")

--- a/create_pr_bot/bot.py
+++ b/create_pr_bot/bot.py
@@ -308,8 +308,6 @@ class CreatePrAIBot:
         Returns:
             The unique ticket ID
         """
-        # ticket_ids = set()
-
         # Common patterns for ticket IDs in commit messages
         # Adjust patterns based on your project's conventions
         patterns = [

--- a/test/unit_test/bot.py
+++ b/test/unit_test/bot.py
@@ -355,21 +355,23 @@ class TestCreatePrAIBot:
         # Verify error message contains branch name
         assert "Base branch 'main' not found" in str(excinfo.value)
 
-    def test_extract_ticket_ids(self, bot):
-        """Test extract_ticket_ids method."""
+    @pytest.mark.parametrize(
+        "git_branch",
+        [
+            "#123/fix_bug",
+            "PROJ-456/implement_feature",
+            "CU-abc123/update-docs",
+            "Task-789/refactor-code",
+            "no-ticket/just-test",
+        ],
+    )
+    def test_extract_ticket_id(self, bot, git_branch: str):
+        """Test extract_ticket_id method."""
         # Create test commits with various ticket patterns
-        commits = [
-            {"message": "Fix bug #123"},
-            {"message": "Implement feature PROJ-456"},
-            {"message": "Update docs CU-abc123"},
-            {"message": "Refactor code Task-789"},
-            {"message": "Non-ticket commit"},
-        ]
-
-        ticket_ids = bot.extract_ticket_ids(commits)
+        ticket_id = bot.extract_ticket_id(git_branch)
 
         # Verify extracted ticket IDs
-        assert sorted(ticket_ids) == sorted(["123", "PROJ-456", "abc123", "789"])
+        assert ticket_id in sorted(["#123", "PROJ-456", "CU-abc123", "Task-789", ""])
 
     def test_get_ticket_details(self, bot, mock_project_management_client):
         """Test get_ticket_details method."""
@@ -613,7 +615,7 @@ class TestCreatePrAIBot:
             patch.object(bot, "is_pr_already_opened", return_value=False),
             patch.object(bot, "fetch_and_merge_latest_from_base_branch", return_value=True),
             patch.object(bot, "get_branch_commits", return_value=[{"message": "Test commit"}]),
-            patch.object(bot, "extract_ticket_ids", return_value=["PROJ-123"]),
+            patch.object(bot, "extract_ticket_id", return_value=["PROJ-123"]),
             patch.object(bot, "get_ticket_details", return_value=[MagicMock()]),
             patch.object(bot, "prepare_ai_prompt", return_value="Test prompt"),
             patch.object(bot, "parse_ai_response", return_value=("Test title", "Test body")),
@@ -633,7 +635,7 @@ class TestCreatePrAIBot:
             patch.object(bot, "is_branch_outdated", return_value=False),
             patch.object(bot, "is_pr_already_opened", return_value=False),
             patch.object(bot, "get_branch_commits", return_value=[{"message": "Test commit"}]),
-            patch.object(bot, "extract_ticket_ids", return_value=["PROJ-123"]),
+            patch.object(bot, "extract_ticket_id", return_value=["PROJ-123"]),
             patch.object(bot, "get_ticket_details", return_value=[MagicMock()]),
             patch.object(bot, "prepare_ai_prompt", return_value="Test prompt"),
             patch.object(bot, "parse_ai_response", return_value=("Test title", "Test body")),
@@ -688,7 +690,7 @@ class TestCreatePrAIBot:
             patch.object(bot, "is_branch_outdated", return_value=False),
             patch.object(bot, "is_pr_already_opened", return_value=False),
             patch.object(bot, "get_branch_commits", return_value=[{"message": "Test commit"}]),
-            patch.object(bot, "extract_ticket_ids", return_value=[]),
+            patch.object(bot, "extract_ticket_id", return_value=[]),
             patch.object(bot, "get_ticket_details", return_value=[]),
             patch.object(bot, "prepare_ai_prompt", return_value="Test prompt"),
         ):


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Fix the logic bug about it should get the task ticket from the git branch name, doesn't from the git commits.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86etjp92f.
    * Relative task IDs: N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    N/A.


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Nothing breaking changes in the features.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Adjust the data processing about it should get the task ticket ID from the git branch name, doesn't from the git commits.
